### PR TITLE
Transfrom로 회전, interpolation, 점프 버그 수정, 애니메이션 개선

### DIFF
--- a/Project Marchen/Assets/Prefabs/NetPrefabs/Player/Test PF.prefab
+++ b/Project Marchen/Assets/Prefabs/NetPrefabs/Player/Test PF.prefab
@@ -145,8 +145,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1971543424177856303}
-  m_RootOrder: 4
+  m_Father: {fileID: 4980385288277362890}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &586207831802628754
 MonoBehaviour:
@@ -1182,6 +1182,7 @@ Transform:
   m_Children:
   - {fileID: 1971543424177856303}
   - {fileID: 6459894363992460278}
+  - {fileID: 5474937174746720843}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1356,9 +1357,9 @@ MonoBehaviour:
   m_Script: {fileID: 1710889294, guid: e725a070cec140c4caffb81624c8c787, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _interpolationDataSource: 3
+  _interpolationDataSource: 0
   InterpolationSpace: 0
-  InterpolationTarget: {fileID: 0}
+  InterpolationTarget: {fileID: 6640970328589365237}
   InterpolateErrorCorrection: 1
   InterpolatedErrorCorrectionSettings:
     MinRate: 3.3
@@ -1385,7 +1386,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _interpolationDataSource: 0
-  playerModel: {fileID: 1971543424177856303}
+  hpHandler: {fileID: 0}
 --- !u!114 &4797138551789220831
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1399,8 +1400,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _interpolationDataSource: 0
+  playerPF: {fileID: 4980385288277362890}
   playerBody: {fileID: 6640970328589365237}
-  playerModel: {fileID: 1971543424177856303}
   moveSpeed: 20
   jumpPower: 40
   dodgePower: 20
@@ -1678,6 +1679,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1971543424177856303}
+  - component: {fileID: 8314418852809699902}
   m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
@@ -1701,10 +1703,23 @@ Transform:
   - {fileID: 7081180801289539154}
   - {fileID: 2721850773489610248}
   - {fileID: 4563216276530025217}
-  - {fileID: 5474937174746720843}
   m_Father: {fileID: 4980385288277362890}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &8314418852809699902
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4323213110611308241}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 1.2
+  m_Height: 4
+  m_Direction: 1
+  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &4490902156900588593
 GameObject:
   m_ObjectHideFlags: 0
@@ -2023,6 +2038,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cameraSpeed: 2
+  cameraAnchorPoint: {fileID: 0}
   bodyAnchorPoint: {fileID: 7081180801289539154}
   layerMask:
     serializedVersion: 2
@@ -2560,6 +2576,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cameraSpeed: 200
+  cameraAnchorPoint: {fileID: 2721850773489610248}
   bodyAnchorPoint: {fileID: 7081180801289539154}
   layerMask:
     serializedVersion: 2
@@ -3075,7 +3092,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6640970328589365237}
-  - component: {fileID: 5489613276585665226}
   m_Layer: 6
   m_Name: Body
   m_TagString: Untagged
@@ -3101,20 +3117,6 @@ Transform:
   m_Father: {fileID: 1971543424177856303}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &5489613276585665226
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8927292589215776640}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 1.2
-  m_Height: 4
-  m_Direction: 1
-  m_Center: {x: 0, y: 2, z: 0}
 --- !u!1 &9034867054821911815
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project Marchen/Assets/Scenes/TestScene(network).unity
+++ b/Project Marchen/Assets/Scenes/TestScene(network).unity
@@ -2555,7 +2555,7 @@ GameObject:
   - component: {fileID: 1280764819}
   - component: {fileID: 1280764818}
   - component: {fileID: 1280764817}
-  m_Layer: 0
+  m_Layer: 3
   m_Name: Cube
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Project Marchen/Assets/Scripts/Camera/LocalCameraHandler.cs
+++ b/Project Marchen/Assets/Scripts/Camera/LocalCameraHandler.cs
@@ -10,8 +10,8 @@ public class LocalCameraHandler : MonoBehaviour
     private float cameraSpeed = 200f;
 
     [Header("Anchor Point")]
-    // [SerializeField]
-    // Transform cameraAnchorPoint;
+    [SerializeField]
+    Transform cameraAnchorPoint;
     [SerializeField]
     Transform bodyAnchorPoint;
 
@@ -53,7 +53,9 @@ public class LocalCameraHandler : MonoBehaviour
     private void Update()
     {
         //조종하는 사람만 실행
-        if(!characterMovementHandler.Object.HasInputAuthority){return;} 
+        if(characterMovementHandler.Object != null)
+            if(!characterMovementHandler.Object.HasInputAuthority)
+                return;
         
         setAimForwardVector();
     }
@@ -67,7 +69,7 @@ public class LocalCameraHandler : MonoBehaviour
         //new
 
         //Move the cameraArm to the position of the player
-        // transform.position = cameraAnchorPoint.position;
+        transform.position = cameraAnchorPoint.position;
 
         cameraRotationX = viewInput.y * Time.deltaTime * cameraSpeed;
         cameraRotationY = viewInput.x * Time.deltaTime * cameraSpeed;

--- a/Project Marchen/Assets/Scripts/Movement/CharacterMovementHandler.cs
+++ b/Project Marchen/Assets/Scripts/Movement/CharacterMovementHandler.cs
@@ -11,19 +11,14 @@ public class CharacterMovementHandler : NetworkBehaviour
     //other components
     [Header("Rotate")]
     [SerializeField]
-    private Transform playerModel;
-    // [SerializeField]
-    // // private Transform playerBody;
-    // NetworkCharacterControllerPrototypeCustom networkCharacterControllerPrototypeCustom;
-    NetworkPlayerController networkPlayerController;
+    // NetworkPlayerController networkPlayerController;
     HPHandler hpHandler;
     NetworkInGameMessages networkInGameMessages;
     NetworkPlayer networkPlayer;
 
     private void Awake()
     {
-        // networkCharacterControllerPrototypeCustom = GetComponent<NetworkCharacterControllerPrototypeCustom>();
-        networkPlayerController = GetComponent<NetworkPlayerController>();
+        // networkyerController = GetComponent<NetworkPlayerController>();
         hpHandler = GetComponent<HPHandler>();
         networkInGameMessages = GetComponent<NetworkInGameMessages>();
         networkPlayer = GetComponent<NetworkPlayer>();
@@ -54,7 +49,8 @@ public class CharacterMovementHandler : NetworkBehaviour
             if(!Object.HasStateAuthority)
                 return;
 
-            if(!isControllerEnable)
+            /*
+            if(!isControllerEnable) //죽은 경우
                 return;
             
             // 입력값 저장
@@ -67,6 +63,7 @@ public class CharacterMovementHandler : NetworkBehaviour
             networkPlayerController.PlayerMove();
             networkPlayerController.PlayerJump();
             networkPlayerController.PlayerDodge();
+            */
             
             //Check if we've fallen off the world
             CheckFallRespawn();
@@ -106,5 +103,9 @@ public class CharacterMovementHandler : NetworkBehaviour
     {
         // networkCharacterControllerPrototypeCustom.Controller.enabled = isEnabled;
         isControllerEnable = isEnabled;
+    }
+    public bool GetCharacterControllerEnabled()
+    {
+        return isControllerEnable;
     }
 }

--- a/Project Marchen/Assets/Scripts/Movement/NetworkPlayerController.cs
+++ b/Project Marchen/Assets/Scripts/Movement/NetworkPlayerController.cs
@@ -6,7 +6,8 @@ using Fusion;
 
 public class NetworkPlayerController : NetworkBehaviour
 {
-    private bool isMove;
+
+    private bool isMove = false;
     private bool isJump;
     private bool isDodge;
 
@@ -23,9 +24,11 @@ public class NetworkPlayerController : NetworkBehaviour
     // 인스펙터
     [Header("오브젝트 연결")]
     [SerializeField]
-    private Transform playerBody;
+    private Transform playerPF;
     [SerializeField]
-    private Transform playerModel;
+    private Transform playerBody;
+    // [SerializeField]
+    // private Transform playerModel;
 
     [Header("설정")]
     // public bool onVelo = true;
@@ -43,83 +46,128 @@ public class NetworkPlayerController : NetworkBehaviour
     private Animator anim;
     private Rigidbody rigid;
     private HPHandler hpHandler;
-    // private CameraController camControl;
-    // private PlayerMain playerMain;
-
+    private CharacterMovementHandler characterMovementHandler;
 
     void Awake()
     {
         anim = GetComponentInChildren<Animator>();
         rigid = GetComponent<Rigidbody>();
         hpHandler = GetComponent<HPHandler>();
-        // camControl = GetComponentInChildren<CameraController>();
-        // playerMain = GetComponent<PlayerMain>();
+        characterMovementHandler = GetComponent<CharacterMovementHandler>();
+    }
+    public override void FixedUpdateNetwork()
+    {
+        if(hpHandler.isDead)
+            return;
+        
+        GroundCheck(); // 바닥 체크 후 anim.SetBool("isJump", false);
+
+        if(Object.HasInputAuthority)
+        {
+            // anim.SetBool("isJump", isJump);
+            RPC_animatonSetBool("isJump", isJump);
+        }
+
+        if(GetInput(out NetworkInputData networkInputData))
+        {
+            if(!characterMovementHandler.GetCharacterControllerEnabled())
+                return;
+
+            // 입력값 저장
+            SetInput(networkInputData);
+
+            // 플레이어 조작
+            PlayerMove();
+            PlayerJump();
+            PlayerDodge();
+        }
+    }
+
+    public void GroundCheck()
+    {
+        if (rigid.velocity.y > 0) // 추락이 아닐 때
+            return;
+
+        feetpos = new Vector3(playerBody.position.x, playerBody.position.y+0.3f, playerBody.position.z);
+
+        //local화 가능? 가능할 듯 update를 이용해서 hasInputAuthority확인 후에 계산하고 networked로 동기화하기
+        if (Physics.BoxCast(feetpos, raySize / 2, Vector3.down, out RaycastHit rayHit, Quaternion.identity, 1f, LayerMask.GetMask("Ground")))
+        {
+            if (rayHit.distance < 1.0f)
+            {
+                isJump = false;
+                // if(Object.HasInputAuthority)
+                    // anim.SetBool("isJump", false);
+                // anim.SetBool("isJump", false);
+                // RPC_animatonSetBool("isJump", false);
+                //Debug.Log("착지");
+            }
+            else
+            {
+                isJump = true;
+                // if(Object.HasInputAuthority)
+                //     anim.SetBool("isJump", true);
+            }
+        }
     }
 
     public void SetInput(NetworkInputData networkInputData)
     {
-        // moveInput = new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical")); // 이동 입력 벡터
         this.isMove = networkInputData.isMove;
         this.moveDir = networkInputData.moveDir;
         this.walkInput = networkInputData.walkInput;
         this.jumpInput = networkInputData.jumpInput;
         this.dodgeInput = networkInputData.dodgeInput;
     }
-    public void GroundCheck()
-    {
-        if (rigid.velocity.y > 0) // 추락이 아닐 때
-            return;
-
-        feetpos = new Vector3(playerBody.position.x, playerBody.position.y, playerBody.position.z);
-
-        //local화 가능?
-        if (Physics.BoxCast(feetpos, raySize / 2, Vector3.down, out RaycastHit rayHit, Quaternion.identity, 1f, LayerMask.GetMask("Ground")))
-        {
-            if (rayHit.distance < 1.0f)
-            {
-                isJump = false;
-                // anim.SetBool("isJump", false);
-                RPC_animatonSetBool("isJump", false);
-                //Debug.Log("착지");
-            }
-        }
-    }
 
     public void PlayerMove()
     {
         if (isDodge && !hpHandler.getIsHit()) // 회피, 피격 중 이동 제한
             return;
-
-        if (isMove)
+        
+        if(Object.HasStateAuthority)
         {
-            // playerModel.forward = moveDir; animatonSetBool      // 카메라 고정
-            RPC_LookForward(moveDir);
+            if (isMove)
+            {
+                RPC_LookForward(moveDir);
 
-            float walkSpeed = (walkInput ? 0.3f : 1f); // 걷기면 속도 0.3배
+                float walkSpeed = (walkInput ? 0.3f : 1f); // 걷기면 속도 0.3배
 
-            rigid.velocity = new Vector3((moveDir * moveSpeed).x * walkSpeed, rigid.velocity.y, (moveDir * moveSpeed).z * walkSpeed); // 물리 이동
+                rigid.velocity = new Vector3((moveDir * moveSpeed).x * walkSpeed, rigid.velocity.y, (moveDir * moveSpeed).z * walkSpeed); // 물리 이동
+            }
+            else
+                rigid.velocity = new Vector3(0f, rigid.velocity.y, 0f); // 미끄러짐 방지
         }
-        else
-            rigid.velocity = new Vector3(0f, rigid.velocity.y, 0f); // 미끄러짐 방지
 
-        // anim.SetBool("isRun", isMove);     // true일 때 걷는 애니메이션, false일 때 대기 애니메이션
-        RPC_animatonSetBool("isRun", isMove);
-        // anim.SetBool("isWalk", walkInput); // isMove, walkOn 둘 다 True 일 때는 걷기
-        RPC_animatonSetBool("isWalk", walkInput);
+        if(Object.HasInputAuthority)
+        {
+            RPC_animatonSetBool("isRun", isMove);
+            RPC_animatonSetBool("isWalk", walkInput);
+            // anim.SetBool("isRun", isMove);     // true일 때 걷는 애니메이션, false일 때 대기 애니메이션
+            // anim.SetBool("isWalk", walkInput); // isMove, walkOn 둘 다 True 일 때는 걷기
+        }
     }
 
     public void PlayerJump()
     {
         if (jumpInput && !isJump && !isDodge && !hpHandler.getIsHit())
         {
+
             isJump = true;
 
-            rigid.AddForce(Vector3.up * jumpPower, ForceMode.Impulse);
+            if(Object.HasStateAuthority)
+            {
+                rigid.AddForce(Vector3.up * jumpPower, ForceMode.Impulse);
+            }
 
-            // anim.SetBool("isJump", true);
-            RPC_animatonSetBool("isJump", true);
-            // anim.SetTrigger("doJump");
-            RPC_animatonSetTrigger("doJump");
+            if(Object.HasInputAuthority)
+            {
+                RPC_animatonSetBool("isJump", true);
+                RPC_animatonSetTrigger("doJump");
+                // anim.SetBool("isJump", true);
+                // anim.SetTrigger("doJump");
+            }
+
         }
     }
 
@@ -127,14 +175,17 @@ public class NetworkPlayerController : NetworkBehaviour
     {
         if (dodgeInput && isMove && !isDodge && !hpHandler.getIsHit())
         {
+            if(Object.HasStateAuthority)
+            {
+                dodgeDir = moveDir; // 회피 방향 기억
+                rigid.AddForce(dodgeDir.normalized * dodgePower, ForceMode.Impulse);
+            }
+
+            if(Object.HasInputAuthority)
+                RPC_animatonSetTrigger("doDodge");
+                // anim.SetTrigger("doDodge");
+
             isDodge = true;
-            dodgeDir = moveDir; // 회피 방향 기억
-            
-            rigid.AddForce(dodgeDir.normalized * dodgePower, ForceMode.Impulse);
-
-            // anim.SetTrigger("doDodge");
-            RPC_animatonSetTrigger("doDodge");
-
             StartCoroutine(PlayerDodgeOut(0.5f));
         }
     }
@@ -148,16 +199,17 @@ public class NetworkPlayerController : NetworkBehaviour
     [Rpc (RpcSources.StateAuthority, RpcTargets.All)]
     private void RPC_LookForward(Vector3 moveDir)
     {
-        playerModel.forward = moveDir;
+        playerPF.forward = moveDir;
     }
 
-    [Rpc (RpcSources.StateAuthority, RpcTargets.All)]
+    [Rpc (RpcSources.InputAuthority, RpcTargets.All)]
     private void RPC_animatonSetBool(string action, bool isDone)
     {
         anim.SetBool(action, isDone);
         // anim.SetTrigger("doJump");
     }
-    [Rpc (RpcSources.StateAuthority, RpcTargets.All)]
+
+    [Rpc (RpcSources.InputAuthority, RpcTargets.All)]
     private void RPC_animatonSetTrigger(string action)
     {
         anim.SetTrigger(action);
@@ -172,4 +224,5 @@ public class NetworkPlayerController : NetworkBehaviour
         Gizmos.DrawCube(feetpos, raySize);
     }
     */
+
 }

--- a/Project Marchen/Assets/Scripts/Network/NetworkPlayer.cs
+++ b/Project Marchen/Assets/Scripts/Network/NetworkPlayer.cs
@@ -60,7 +60,7 @@ public class NetworkPlayer : NetworkBehaviour, IPlayerLeft
             localUI.SetActive(true);
 
             //Detach camera if enabled
-            // localCameraHandler.transform.parent = null;
+            localCameraHandler.transform.parent = null;
 
             RPC_SetNickName(GameManager.instance.playerNickName);
 


### PR DESCRIPTION
* body가 아닌 Transform으로 회전
* network rigidbody의 interpolation 사용 가능해짐. 부드러운 움직임.
* 점프 bug 해결 : GroundCheck raycast의 시작 위치를 조금 상승 조정.
* 서버가 아닌 조종하는 플레이어에서 애니메이션에 대한 RPC를 요청함에 따라서 애니매이션의 반응 속도가 상승함.