### PR TITLE
[BUGFIX] 무기 장전이 중복되는 버그 #187

### DIFF
--- a/Project Marchen/Assets/Scripts/Movement/AttackHandler.cs
+++ b/Project Marchen/Assets/Scripts/Movement/AttackHandler.cs
@@ -70,7 +70,6 @@ public class AttackHandler : NetworkBehaviour
     /// @see WeaponHandler
     public void DoAttack(Vector3 aimDir)
     {
-        StopReload();
         weaponHandler.Attack(aimDir);
         Debug.Log("DoAttack");
     }

--- a/Project Marchen/Assets/Scripts/Movement/NetworkPlayerController.cs
+++ b/Project Marchen/Assets/Scripts/Movement/NetworkPlayerController.cs
@@ -280,6 +280,10 @@ public class NetworkPlayerController : NetworkBehaviour
     {
         isReload = bol;
     }
+    public bool GetIsReload()
+    {
+        return isReload;
+    }
     public void SetIsInteract(bool bol)
     {
         isInteract = bol;

--- a/Project Marchen/Assets/Scripts/Weapon/GunHandler.cs
+++ b/Project Marchen/Assets/Scripts/Weapon/GunHandler.cs
@@ -63,9 +63,9 @@ public class GunHandler : WeaponHandler
         if (curAmmo <= 0)
         {
             if(!networkPlayerController.GetIsReload()){
-                networkPlayerController.SetIsAttack(false);
                 Reload();
             }
+            networkPlayerController.SetIsAttack(false);
             return;
         }
         StopReload();

--- a/Project Marchen/Assets/Scripts/Weapon/GunHandler.cs
+++ b/Project Marchen/Assets/Scripts/Weapon/GunHandler.cs
@@ -62,11 +62,13 @@ public class GunHandler : WeaponHandler
     {
         if (curAmmo <= 0)
         {
-            networkPlayerController.SetIsAttack(false);
-            Reload();
+            if(!networkPlayerController.GetIsReload()){
+                networkPlayerController.SetIsAttack(false);
+                Reload();
+            }
             return;
         }
-
+        StopReload();
         networkPlayerController.RPC_LookForward(aimDir);
         RPC_animatonSetTrigger("doShot");
         RPC_AudioPlay("shot");

--- a/Project Marchen/Assets/Scripts/Weapon/TrackerHandler.cs
+++ b/Project Marchen/Assets/Scripts/Weapon/TrackerHandler.cs
@@ -66,11 +66,12 @@ public class TrackerHandler : WeaponHandler
     {
         if (curAmmo <= 0)
         {
+            if(!networkPlayerController.GetIsReload())
+                Reload();
             networkPlayerController.SetIsAttack(false);
-            Reload();
             return;
         }
-
+        StopReload();
         networkPlayerController.RPC_LookForward(aimDir);
         RPC_animatonSetTrigger("doShot");
         StartCoroutine("Shot");
@@ -121,7 +122,6 @@ public class TrackerHandler : WeaponHandler
     /// @brief 재장전한다.
     public override void Reload()
     {
-        StopReload();
         RPC_animatonSetTrigger("doReload");
         RPC_AudioPlay("reload");
         networkPlayerController.SetIsReload(true);
@@ -131,7 +131,6 @@ public class TrackerHandler : WeaponHandler
     public override void StopReload()
     {
         StopCoroutine("ReloadOut");
-        //StopAllCoroutines();
         networkPlayerController.SetIsReload(false);
     }
 


### PR DESCRIPTION
* 잔탄이 있으면 장전 중 공격 가능
* 잔탄이 없으면 장전 중 취소 불가능